### PR TITLE
A quick'n'dirty list of the existing p-modules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,36 @@ I plan on using this space to document my promise modules, useful promise patter
 
 Star this repo to show your interest, so I can know whether to prioritize this work.
 
+## The list so far
+
+- **[p-all](https://github.com/sindresorhus/p-all)**: Run promise-returning & async functions concurrently with optional limited concurrency
+- **[p-any](https://github.com/sindresorhus/p-any)**: Wait for any promise to be fulfilled
+- **[p-catch-if](https://github.com/sindresorhus/p-catch-if)**: Conditional promise catch handler
+- **[p-debounce](https://github.com/sindresorhus/p-debounce)**: Debounce promise-returning & async functions
+- **[p-defer](https://github.com/sindresorhus/p-defer)**: Create a deferred promise
+- **[p-each-series](https://github.com/sindresorhus/p-each-series)**: Iterate over promises serially
+- **[p-filter](https://github.com/sindresorhus/p-filter)**: Filter promises concurrently
+- **[p-finally](https://github.com/sindresorhus/p-finally)**: `Promise#finally()` ponyfill - Invoked when the promise is settled regardless of outcome
+- **[p-if](https://github.com/sindresorhus/p-if)**: Conditional promise chains
+- **[p-limit](https://github.com/sindresorhus/p-limit)**: Run multiple promise-returning & async functions with limited concurrency
+- **[p-log](https://github.com/sindresorhus/p-log)**: Log the value/error of a promise
+- **[p-map](https://github.com/sindresorhus/p-map)**: Map over promises concurrently
+- **[p-map-series](https://github.com/sindresorhus/p-map-series)**: Map over promises serially
+- **[p-memoize](https://github.com/sindresorhus/p-memoize)**: Memoize promise-returning & async functions
+- **[p-pipe](https://github.com/sindresorhus/p-pipe)**: Compose promise-returning & async functions into a reusable pipeline
+- **[p-props](https://github.com/sindresorhus/p-props)**: Like `Promise.all()` but for `Map` and `Object`
+- **[p-queue](https://github.com/sindresorhus/p-queue)**: Promise queue with concurrency control
+- **[p-race](https://github.com/sindresorhus/p-race)**: A better `Promise.race()`
+- **[p-reduce](https://github.com/sindresorhus/p-reduce)**: Reduce a list of values using promises into a promise for a value
+- **[p-retry](https://github.com/sindresorhus/p-retry)**: Retry a promise-returning or async function
+- **[p-settle](https://github.com/sindresorhus/p-settle)**: Settle promises concurrently and get their fulfillment value or rejection reason
+- **[p-some](https://github.com/sindresorhus/p-some)**: Wait for a specified number of promises to be fulfilled
+- **[p-tap](https://github.com/sindresorhus/p-tap)**: Tap into a promise chain without affecting its value or state
+- **[p-throttle](https://github.com/sindresorhus/p-throttle)**: Throttle promise-returning & async functions
+- **[p-timeout](https://github.com/sindresorhus/p-timeout)**: Timeout a promise after a specified amount of time
+- **[p-times](https://github.com/sindresorhus/p-times)**: Run promise-returning & async functions a specific number of times concurrently
+- **[p-try](https://github.com/sindresorhus/p-try)**: `Promise#try()` ponyfill - Starts a promise chain
+- **[p-wait-for](https://github.com/sindresorhus/p-wait-for)**: Wait for a condition to be true
 
 ## License
 


### PR DESCRIPTION
Github's repo search results are a horrible UI for browsing the promise libraries - a simple bullet-point list in one place would be way nicer for me.

Also, I'm loving these modules, thanks so much for a handy promise toolbag of small composable modules!