### PR TITLE
More common `.spread` pattern, w/ ES6 example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,21 +133,26 @@ const getData = async id => {
 Bluebird:
 
 ```js
-Promise.resolve([1, 2])
-	.then(getUserLoginCount)
-	.spread((one, two) => {
-		console.log(one, two); //=> 10 20
-	});
+const getLoginData = ids =>
+	Promise.resolve(ids)
+		.then(getUserLoginCount)
+		.spread((...counts) => {
+			console.log(counts); //=> 10 20
+			return [ids, counts] 
+		});
 ```
 
 Instead, use [destructuring](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment):
 
 ```js
-Promise.resolve([1, 2])
-	.then(getUserLoginCount)
-	.all().then(([one, two]) => {
-		console.log(one, two); //=> 10 20
-	});
+const getLoginData = ids =>
+	Promise.resolve(ids)
+		.then(getUserLoginCount)
+		.then(results => Promise.all(results))
+		.then(counts => {
+			console.log(counts); //=> 10 20
+			return [ids, counts] 
+		});
 ```
 
 ### What about something like [`Bluebird.join()`](http://bluebirdjs.com/docs/api/promise.join.html)?

--- a/readme.md
+++ b/readme.md
@@ -133,19 +133,21 @@ const getData = async id => {
 Bluebird:
 
 ```js
-Promise.resolve([1, 2]).spread((one, two) => {
-	console.log(one, two);
-	//=> 1 2
-});
+Promise.resolve([1, 2])
+	.then(getUserLoginCount)
+	.spread((one, two) => {
+		console.log(one, two); //=> 1 2
+	});
 ```
 
 Instead, use [destructuring](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment):
 
 ```js
-Promise.resolve([1, 2]).then(([one, two]) => {
-	console.log(one, two);
-	//=> 1 2
-});
+Promise.resolve([1, 2])
+	.then(getUserLoginCount)
+	..all().then((one, two) => {
+		console.log(one, two); //=> 1 2
+	});
 ```
 
 ### What about something like [`Bluebird.join()`](http://bluebirdjs.com/docs/api/promise.join.html)?

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ Bluebird:
 Promise.resolve([1, 2])
 	.then(getUserLoginCount)
 	.spread((one, two) => {
-		console.log(one, two); //=> 1 2
+		console.log(one, two); //=> 10 20
 	});
 ```
 
@@ -145,8 +145,8 @@ Instead, use [destructuring](https://developer.mozilla.org/en/docs/Web/JavaScrip
 ```js
 Promise.resolve([1, 2])
 	.then(getUserLoginCount)
-	..all().then((one, two) => {
-		console.log(one, two); //=> 1 2
+	.all().then(([one, two]) => {
+		console.log(one, two); //=> 10 20
 	});
 ```
 


### PR DESCRIPTION
I added the missing `.all()` for the ES6 example (for when previous `.then` is called multiple times).

Also didn't think you wanted the dummy method `getUserLoginCount`
```js
const getUserLoginCount = id => id * 10;
```


